### PR TITLE
Fix exception loading assembly that references System.ValueTuple

### DIFF
--- a/src/XmlDocMarkdown/XmlDocMarkdown.csproj
+++ b/src/XmlDocMarkdown/XmlDocMarkdown.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="ArgsReading" Version="1.1.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This allows XmlDocMarkdown to reflect over a `netstandard1.4` dll that references `System.ValueTuple`. Without this DLL being present, the following exception is thrown:

```
Could not load file or assembly 'System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.
```

Updating XmlDocMarkdown to target `net47` (which includes `System.ValueTuple`) did not fix this error.