### PR TITLE
Order implemented interfaces by name.

### DIFF
--- a/docs/ExampleAssembly/ExampleDerivedClass.md
+++ b/docs/ExampleAssembly/ExampleDerivedClass.md
@@ -3,7 +3,7 @@
 A class that derives from [`ExampleClass`](ExampleClass.md).
 
 ```csharp
-public class ExampleDerivedClass : ExampleClass, IExampleInterface, IEnumerable<string>
+public class ExampleDerivedClass : ExampleClass, IEnumerable<string>, IExampleInterface
 ```
 
 ## Public Members

--- a/docs/ExampleAssembly/IExampleDerivedInterface.md
+++ b/docs/ExampleAssembly/IExampleDerivedInterface.md
@@ -3,7 +3,7 @@
 A derived interface.
 
 ```csharp
-public interface IExampleDerivedInterface : IReadOnlyDictionary<string, IExampleInterface>, IDictionary<string, IExampleInterface>
+public interface IExampleDerivedInterface : IDictionary<string, IExampleInterface>, IReadOnlyDictionary<string, IExampleInterface>
 ```
 
 ## See Also

--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -1052,7 +1052,8 @@ namespace XmlDocMarkdown.Core
 					isFirstBase = false;
 				}
 
-				var baseInterfaces = typeInfo.ImplementedInterfaces.Select(x => x.GetTypeInfo()).Where(x => x.IsPublic).ToList();
+				var baseInterfaces = typeInfo.ImplementedInterfaces.Select(x => x.GetTypeInfo()).Where(x => x.IsPublic)
+					.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).ToList();
 				foreach (var baseInterface in baseInterfaces)
 				{
 					if (!(typeKind == TypeKind.Class && baseInterface.IsAssignableFrom(typeInfo.BaseType.GetTypeInfo())) &&


### PR DESCRIPTION
TypeInfo.ImplementedInterfaces does not specify an order, and Mono returns types in a different order than what .NET Framework on Windows returns.