### PR TITLE
langword support

### DIFF
--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -240,7 +240,7 @@ namespace XmlDocMarkdown.Core
 						foreach (var seeAlsoInfo in xmlDocMember.SeeAlso)
 						{
 							string xmlDocName = seeAlsoInfo.Ref;
-							if (memberContext.MembersByXmlDocName.TryGetValue(xmlDocName, out var seeAlsoMember))
+							if (xmlDocName != null && memberContext.MembersByXmlDocName.TryGetValue(xmlDocName, out var seeAlsoMember))
 								seeAlsoMembers.Add(seeAlsoMember);
 						}
 					}
@@ -1822,6 +1822,8 @@ namespace XmlDocMarkdown.Core
 					text = XmlDocUtility.GetShortNameForXmlDocRef(inline.SeeRef);
 				else if (inline.LinkUrl != null)
 					text = inline.LinkUrl;
+				else if (inline.LangWord != null)
+					text = SurroundCode(inline.LangWord);
 			}
 
 			if (text.Length != 0)

--- a/src/XmlDocMarkdown.Core/XmlDocInline.cs
+++ b/src/XmlDocMarkdown.Core/XmlDocInline.cs
@@ -6,6 +6,8 @@ namespace XmlDocMarkdown.Core
 
 		public string SeeRef { get; set; }
 
+		public string LangWord { get; set; }
+
 		public string LinkUrl { get; set; }
 
 		public bool IsCode { get; set; }

--- a/src/XmlDocMarkdown.Core/XmlDocMember.cs
+++ b/src/XmlDocMarkdown.Core/XmlDocMember.cs
@@ -188,7 +188,7 @@ namespace XmlDocMarkdown.Core
 					break;
 
 				case "see":
-					m_block?.Inlines.Add(new XmlDocInline { Text = xElement.Value, SeeRef = xElement.Attribute("cref")?.Value, LinkUrl = xElement.Attribute("href")?.Value });
+					m_block?.Inlines.Add(new XmlDocInline { Text = xElement.Value, SeeRef = xElement.Attribute("cref")?.Value, LinkUrl = xElement.Attribute("href")?.Value, LangWord = xElement.Attribute("langword")?.Value });
 					break;
 
 				case "a":


### PR DESCRIPTION
fixes #37
fixes NRE if seealso does not contain `cref` attribute (by mistake it may contain `href`)