### PR TITLE
Add targets for netcoreapp2.2 and netcoreapp2.1

### DIFF
--- a/src/xmldocmd/xmldocmd.csproj
+++ b/src/xmldocmd/xmldocmd.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <Description>A .NET Core Global Tool that generates Markdown from .NET XML documentation comments.</Description>
     <PackageTags>.NET XML documentation comments Markdown</PackageTags>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Let's keep the backward compatibility of the package. Moreover, it is so simple.