### PR TITLE
Default null names of implied parameters generated by the F# compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Thumbs.db
 nCrunchTemp*
 _ReSharper*
 launchSettings.json
+packages/FSharp.Cor*
+packages/System.ValueTupl*

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,9 @@
 # Version History
 
+### 2.1.0
+
+* Prevent NRE for F# compiler generated implicit parameters
+
 ### 2.0.2
 
 * `xmldocmd` can also support .NET Core 2.1 and .NET Core 2.2. (Thanks [sungam3r](https://github.com/sungam3r)!)

--- a/XmlDocMarkdown.sln
+++ b/XmlDocMarkdown.sln
@@ -33,7 +33,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		VersionHistory.md = VersionHistory.md
 	EndProjectSection
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpWithNulls", "Tests\FSharpWithNulls\FSharpWithNulls.fsproj", "{3CE29B0C-6CA6-4AF2-B2A8-A1DD8EDC0B39}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpWithNulls", "tests\FSharpWithNulls\FSharpWithNulls.fsproj", "{3CE29B0C-6CA6-4AF2-B2A8-A1DD8EDC0B39}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/XmlDocMarkdown.sln
+++ b/XmlDocMarkdown.sln
@@ -33,6 +33,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		VersionHistory.md = VersionHistory.md
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpWithNulls", "Tests\FSharpWithNulls\FSharpWithNulls.fsproj", "{3CE29B0C-6CA6-4AF2-B2A8-A1DD8EDC0B39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,10 @@ Global
 		{D787BB4B-8E32-4155-B855-9B06D1CA5FED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D787BB4B-8E32-4155-B855-9B06D1CA5FED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D787BB4B-8E32-4155-B855-9B06D1CA5FED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CE29B0C-6CA6-4AF2-B2A8-A1DD8EDC0B39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CE29B0C-6CA6-4AF2-B2A8-A1DD8EDC0B39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CE29B0C-6CA6-4AF2-B2A8-A1DD8EDC0B39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CE29B0C-6CA6-4AF2-B2A8-A1DD8EDC0B39}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -1258,8 +1258,10 @@ namespace XmlDocMarkdown.Core
 				yield return "";
 
 				bool isFirstParameter = true;
+				var index = -1;
 				foreach (var parameterInfo in parameterInfos)
 				{
+					++index;
 					if (!isFirstParameter)
 					{
 						yield return ", ";
@@ -1286,7 +1288,7 @@ namespace XmlDocMarkdown.Core
 					yield return " ";
 					if (IsKeyword(parameterInfo.Name))
 						yield return "@";
-					yield return parameterInfo.Name ?? "_"; // default to a discard if null
+					yield return parameterInfo.Name ?? "P_" + index.ToString(CultureInfo.InvariantCulture); // default as per ILSpy if null
 
 					if (ParameterHasDefaultValue(parameterInfo))
 					{

--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -40,7 +40,7 @@ namespace XmlDocMarkdown.Core
 
 		public string FrontMatter { get; internal set; }
 
-		public bool PermalinkPretty { get; internal set; }
+		public bool PermalinkPretty{ get; internal set; }
 
 		private IEnumerable<NamedText> DoGenerateOutput(Assembly assembly, XmlDocAssembly xmlDocAssembly)
 		{
@@ -97,7 +97,7 @@ namespace XmlDocMarkdown.Core
 			var context = new MarkdownContext(xmlDocAssembly, membersByXmlDocName, assemblyFileName, sourceCodePath, rootNamespace, RootPageLocation);
 			yield return CreateNamedText(context.PageLocation, null, assemblyName, writer =>
 			{
-				var front = GetFrontMatter(assemblyName, $"{safeAssemblyName}" + (PermalinkPretty ? "Assembly" : "") + extension);
+				var front = GetFrontMatter(assemblyName, $"{safeAssemblyName}" + (PermalinkPretty ? "Assembly" :"") + extension);
 				if (!string.IsNullOrEmpty(front))
 				{
 					writer.WriteLine(front);

--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -40,7 +40,7 @@ namespace XmlDocMarkdown.Core
 
 		public string FrontMatter { get; internal set; }
 
-		public bool PermalinkPretty{ get; internal set; }
+		public bool PermalinkPretty { get; internal set; }
 
 		private IEnumerable<NamedText> DoGenerateOutput(Assembly assembly, XmlDocAssembly xmlDocAssembly)
 		{
@@ -97,7 +97,7 @@ namespace XmlDocMarkdown.Core
 			var context = new MarkdownContext(xmlDocAssembly, membersByXmlDocName, assemblyFileName, sourceCodePath, rootNamespace, RootPageLocation);
 			yield return CreateNamedText(context.PageLocation, null, assemblyName, writer =>
 			{
-				var front = GetFrontMatter(assemblyName, $"{safeAssemblyName}" + (PermalinkPretty ? "Assembly" :"") + extension);
+				var front = GetFrontMatter(assemblyName, $"{safeAssemblyName}" + (PermalinkPretty ? "Assembly" : "") + extension);
 				if (!string.IsNullOrEmpty(front))
 				{
 					writer.WriteLine(front);
@@ -1286,7 +1286,7 @@ namespace XmlDocMarkdown.Core
 					yield return " ";
 					if (IsKeyword(parameterInfo.Name))
 						yield return "@";
-					yield return parameterInfo.Name;
+					yield return parameterInfo.Name ?? "_"; // default to a discard if null
 
 					if (ParameterHasDefaultValue(parameterInfo))
 					{

--- a/tests/FSharpWithNulls/FSharpWithNulls.fsproj
+++ b/tests/FSharpWithNulls/FSharpWithNulls.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <LangVersion></LangVersion>
@@ -8,4 +8,6 @@
   <ItemGroup>
     <Compile Include="Library.fs" />
   </ItemGroup>
+
+  <Target Name="MSBuild14placeholder" />
 </Project>

--- a/tests/FSharpWithNulls/FSharpWithNulls.fsproj
+++ b/tests/FSharpWithNulls/FSharpWithNulls.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <LangVersion></LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/FSharpWithNulls/Library.fs
+++ b/tests/FSharpWithNulls/Library.fs
@@ -1,0 +1,27 @@
+namespace ExtensionMethods
+
+open System.Collections
+open System.Runtime.CompilerServices
+
+// F# extension style
+// implicit `this` parameter has a null name
+module Augment =
+  type System.Object with
+    member self.IsNotNull
+      with get() =
+        self |> isNull |> not
+
+open Augment
+
+// C# extension style
+// no `this` parameter syntactic sugar available
+// so explicitly decorate with `ExtensionAttribute`
+[<Extension>]
+module Utility =
+  [<Extension>]
+  let SafeLength (x : IEnumerable) =
+    if x.IsNotNull
+    then  x |> Seq.cast<obj> |> Seq.length
+    else -1
+
+type Fix<'T> = delegate of 'T -> Fix<'T>

--- a/tests/XmlDocMarkdown.Tests/MarkdownGeneratorTests.cs
+++ b/tests/XmlDocMarkdown.Tests/MarkdownGeneratorTests.cs
@@ -16,5 +16,14 @@ namespace XmlDocMarkdown.Tests
 				Path.Combine(Path.GetTempPath(), "MarkdownGeneratorTests"),
 				new XmlDocMarkdownSettings { IsDryRun = true });
 		}
+
+		[Fact]
+		public void FSharpWithNulls()
+		{
+			XmlDocMarkdownGenerator.Generate(
+				typeof(ExtensionMethods.Augment).GetTypeInfo().Assembly.Location,
+				Path.Combine(Path.GetTempPath(), "MarkdownGeneratorTests"),
+				new XmlDocMarkdownSettings { IsDryRun = true });
+		}
 	}
 }

--- a/tests/XmlDocMarkdown.Tests/XmlDocMarkdown.Tests.csproj
+++ b/tests/XmlDocMarkdown.Tests/XmlDocMarkdown.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\XmlDocMarkdown.Core\XmlDocMarkdown.Core.csproj" />
     <ProjectReference Include="..\..\tools\ExampleAssembly\ExampleAssembly.csproj" />
+    <ProjectReference Include="..\FSharpWithNulls\FSharpWithNulls.fsproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addresses issue #73 

If a parameter name is null, generate a dummy value of the form `P_# ` where `#` is the zero-based index number of the null parameter.