### PR TITLE
Address the missing dependencies issues

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,9 @@
 # Version History
 
+### 2.x.x
+
+* Add a -- potentially slow -- scan for assembly dependencies, rather than fail with `ReflectionTypeLoadException`, based on [a previous F# implementation](https://github.com/SteveGilham/altcover/blob/498da6195ee434743fb6b0bf6d0ce9ab522ede58/AltCover/Instrument.fs#L235-L284)
+
 ### 2.1.0
 
 * Add `--skip-unbrowsable`, `--namespace-pages`, `--front-matter`, `--permalink`, `--toc`, and `--toc-prefix`.

--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -120,6 +120,7 @@ namespace XmlDocMarkdown.Core
 						{
 							var assembly = Assembly.LoadFile(f);
 							resolutionTable.Add(a.Name, assembly);
+							Console.WriteLine($"Resolved {a.Name}");
 							return assembly;
 						})
 						.FirstOrDefault();

--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -110,7 +110,7 @@ namespace XmlDocMarkdown.Core
 				// and later versions first
 				.OrderByDescending(f => f)
 				// match the assembly name
-				.Where(f =>
+				.FirstOrDefault(f =>
 				{
 					try
 					{
@@ -131,8 +131,8 @@ namespace XmlDocMarkdown.Core
 						else
 							throw;
 					}
-				})
-				.FirstOrDefault();
+				});
+
 			if (matched != null)
 			{
 				Console.WriteLine($"Resolved {args.Name}");

--- a/tests/XmlDocMarkdown.Tests/MarkdownGeneratorTests.cs
+++ b/tests/XmlDocMarkdown.Tests/MarkdownGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
 using ExampleAssembly;
@@ -24,6 +25,24 @@ namespace XmlDocMarkdown.Tests
 				typeof(ExtensionMethods.Augment).GetTypeInfo().Assembly.Location,
 				Path.Combine(Path.GetTempPath(), "MarkdownGeneratorTests"),
 				new XmlDocMarkdownSettings { IsDryRun = true });
+		}
+
+		[Fact]
+		public void MatchNugetDependencies()
+		{
+			var generatorAssembly = typeof(XmlDocMarkdownGenerator).Assembly;
+			var generatorType = generatorAssembly.GetType("XmlDocMarkdown.Core.MarkdownGenerator");
+			var table = generatorType.GetField("resolutionTable",
+				BindingFlags.Static | BindingFlags.NonPublic).GetValue(null)
+				as ConcurrentDictionary<string, Assembly>;
+			table.Clear();
+
+			XmlDocMarkdownGenerator.Generate(
+				typeof(Cake.XmlDocMarkdown.XmlDocCakeAddin).GetTypeInfo().Assembly.Location,
+				Path.Combine(Path.GetTempPath(), "MarkdownGeneratorTests"),
+				new XmlDocMarkdownSettings { IsDryRun = true });
+
+			Assert.True(table.Count > 0, "Was empty");
 		}
 	}
 }

--- a/tests/XmlDocMarkdown.Tests/XmlDocMarkdown.Tests.csproj
+++ b/tests/XmlDocMarkdown.Tests/XmlDocMarkdown.Tests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Cake.XmlDocMarkdown\Cake.XmlDocMarkdown.csproj" />
     <ProjectReference Include="..\..\src\XmlDocMarkdown.Core\XmlDocMarkdown.Core.csproj" />
     <ProjectReference Include="..\..\tools\ExampleAssembly\ExampleAssembly.csproj" />
     <ProjectReference Include="..\FSharpWithNulls\FSharpWithNulls.fsproj" />


### PR DESCRIPTION
This should resolve most of issue #88 and its subset issue #69.  

Issue #88 type 2 resolution failures for certain types of .net framework-targeted assembly could be addressed by adding `$(WinDir)\Microsoft.NET\Framework` (and, plausibly, its Mono equivalent) to the list of directories to scan, if there is ever a sufficient use-case.

Alternatively, with the nuget cache look-up sorted, an alternative would be to declare classic .net framework  to be unsupported -- I only use those builds as a target because it's a work-round for the nuget cache issue -- and delete the #88 [part 1 handler clause](https://github.com/SteveGilham/XmlDocMarkdown/blob/4a52b7a63d06e22d292f354b7f5cbda2e97de6ab/src/XmlDocMarkdown.Core/MarkdownGenerator.cs#L60-L70) entirely.