### PR TITLE
Update Cake addin to allow the documentation to flow through the website

### DIFF
--- a/src/Cake.XmlDocMarkdown/XmlDocCakeAddin.cs
+++ b/src/Cake.XmlDocMarkdown/XmlDocCakeAddin.cs
@@ -10,6 +10,7 @@ namespace Cake.XmlDocMarkdown
 	/// <summary>
 	/// The Cake addin.
 	/// </summary>
+	[CakeAliasCategory("XmlDocMarkdown")]
 	[CakeNamespaceImport("XmlDocMarkdown.Core")]
 	public static class XmlDocCakeAddin
 	{


### PR DESCRIPTION
The Cake website automatically documents Cake addins by reading the XML docs in the assembly, however it requires an attribute `CakeAliasCategory` to assign the Cake aliases to a category.

The documentation for the Cake.XmlDocMarkdown add-in is here: https://cakebuild.net/extensions/cake-xmldocmarkdown/

---

### Before this PR:

![image](https://user-images.githubusercontent.com/177608/103414648-2af5fe80-4b55-11eb-85ce-286b5bb5ecb8.png)

---

### After this PR:

![image](https://user-images.githubusercontent.com/177608/103414657-32b5a300-4b55-11eb-8865-edd08747db8f.png)

---

Closes https://github.com/cake-build/website/issues/1156