### PR TITLE
Update compatibility of the Cake addin to the next range [0.33.0, 1.0.0)

### DIFF
--- a/src/Cake.XmlDocMarkdown/Cake.XmlDocMarkdown.csproj
+++ b/src/Cake.XmlDocMarkdown/Cake.XmlDocMarkdown.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.28.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Cake.XmlDocMarkdown addin is currently classified as compatible with Cake from v0.28.0 to v0.32.1 because it references Cake.Core v0.28.0.

[![image](https://user-images.githubusercontent.com/177608/103415058-ee2b0700-4b56-11eb-9d22-bd70ddac3f64.png)](https://cakebuild.net/extensions/cake-xmldocmarkdown/)

[The current recommended best practice is to reference v0.33.0 at a minimum](https://cakebuild.net/docs/extending/addins/best-practices#cake-version-to-build-addins-against). By referencing Cake.Core v0.33.0, it will put Cake.XmlDocMarkdown in the next compatibility range from v0.33.0 to v0.38.5, with v0.38.5 being the latest stable release of Cake as of this writing.

