### PR TITLE
xmldocmd: target net5.0

### DIFF
--- a/src/xmldocmd/xmldocmd.csproj
+++ b/src/xmldocmd/xmldocmd.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <Description>A .NET tool that generates Markdown from .NET XML documentation comments.</Description>
     <PackageTags>.NET XML documentation comments Markdown</PackageTags>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Running `xmldocmd` on a .net 5.0 assembly will currently fail:

```
>xmldocmd bin\Debug\net5.0\publish\library.dll docs
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types.
Could not load file or assembly 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
[...]
```

Adding .net5.0 as a tool target fixes this.