### PR TITLE
Code tag extension to support a 'lang' or 'language' attribute.

### DIFF
--- a/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
+++ b/src/XmlDocMarkdown.Core/MarkdownGenerator.cs
@@ -2166,7 +2166,7 @@ namespace XmlDocMarkdown.Core
 				{
 					if (block.IsCode)
 					{
-						yield return "```csharp";
+						yield return "``` " + block.CodeLanguage;
 						foreach (var inline in block.Inlines)
 							yield return inline.Text!.Replace(Environment.NewLine, ActualNewLine);
 						yield return "```";

--- a/src/XmlDocMarkdown.Core/XmlDocBlock.cs
+++ b/src/XmlDocMarkdown.Core/XmlDocBlock.cs
@@ -8,6 +8,8 @@ namespace XmlDocMarkdown.Core
 
 		public bool IsCode { get; set; }
 
+		public string CodeLanguage { get; set; } = "csharp";
+
 		public XmlDocListKind? ListKind { get; set; }
 
 		public int ListDepth { get; set; }


### PR DESCRIPTION
The motivation for this pull request is the poor (non-existing) support for code language in `<code>` sections by the XML documentation specification: [D.3.3 `<code>`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments#d33-code).  Oftentimes it is necessary to include code fragments in the documentation which are not CSHARP. Typical examples include XML, HTML, Javascript , or [mermaid diagram](https://mermaid.js.org/) code. To support these use cases the other tools such as the Sandcastle help file build allow
additional  `lang`  or `language` attributes on the `<code>` tag.

Example:
~~~ XML
<code lang="Javascript">
if (/\S+@\S+\.\S+/.test('david@codeshack.io')) {
    console.log('Email is valid!');
} else {
    console.log('Email is invalid!');
}
</code>
~~~

would be converted to this Markdown fenced block:

~~~ Markdown
``` Javascript
if (/\S+@\S+\.\S+/.test('david@codeshack.io')) {
    console.log('Email is valid!');
} else {
    console.log('Email is invalid!');
}
```
~~~

In the code changes provided in this pull request I have:
*  added support for `lang` or `language` attributes to generate Markdown output as shown in the example above.
* improved the `TrimCode` method to be smarter about finding the optimal indent length of a code block.

I hope you find this contribution useful.

WetHat